### PR TITLE
Fix for get_current_orders function.

### DIFF
--- a/src/pywmapi/orders/models.py
+++ b/src/pywmapi/orders/models.py
@@ -75,7 +75,7 @@ class OrderItem(OrderCommon):
 
     item: ItemInOrder
     user: Optional[UserShort] = None
-    platform: Platform = None
+    platform: Optional[Platform] = None
 
 
 @define(kw_only=True)

--- a/src/pywmapi/orders/models.py
+++ b/src/pywmapi/orders/models.py
@@ -75,6 +75,7 @@ class OrderItem(OrderCommon):
 
     item: ItemInOrder
     user: Optional[UserShort] = None
+    platform: Platform = None
 
 
 @define(kw_only=True)


### PR DESCRIPTION
It sounds like Waframe Market includes now the platform in the get_current_orders request:
'sell_orders': [{'visible': True,
    ...
    'platform': 'pc'

Therefore I added platform attribute to the OrderItem structure:
platform: Platform = None

Edit: I forgot to add the Optional