### PR TITLE
Add vaulted field to FullItem

### DIFF
--- a/src/pywmapi/items/models.py
+++ b/src/pywmapi/items/models.py
@@ -48,6 +48,8 @@ class ItemFull(ModelBase):
     """Cyan stars count. Only for Ayatan Treasures."""
     amber_stars: Optional[int] = None
     """Amber stars count. Only for Ayatan Treasures."""
+    vaulted: Optional[bool] = None
+    """Vaulted status of a relic. Only for relics."""
     ducats: Optional[int] = None
     set_root: Optional[bool] = None
     mastery_level: Optional[int] = None


### PR DESCRIPTION
Add the `vaulted` field to `FullItem` which indicates wether a relic is currently vaulted or not.
This info is returned by the warframe.market api but not stored in the `FullItem` class. Could be useful info :)