### PR TITLE
add proper support for profile achievements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ For now, the implemented function is listed below:
   * 🆖 get current user's profile
   * 🆖 manage current user profile
   * ✅ get a user's profile
-  * 🔲 get all of a user's achievements
-  * 🔲 get all of a user's reviews
+  * ✅ get all of a user's achievements
+  * 🆖 get all of a user's reviews
   * 🆖 set current user's online/offline status
 * items
   * ✅ list all tradable items

--- a/src/pywmapi/profile/api.py
+++ b/src/pywmapi/profile/api.py
@@ -8,6 +8,7 @@ from .models import *
 __all__ = [
     "get_current_user",
     "get_profile_by_username",
+    "get_profile_achievements",
     "set_profile_status",
 ]
 
@@ -41,8 +42,24 @@ def get_profile_by_username(username: str) -> Profile:
     res = requests.get(
         API_BASE_URL + f"/user/{username}",
     )
+    achievementRes = requests.get(
+        API_BASE_URL + f"/achievements/user/{username}" 
+    )
     check_wm_response(res)
-    return Profile.from_dict(res.json()["data"])
+    check_wm_response(achievementRes)
+    return Profile.from_dict(res.json()["data"], achievementRes.json()["data"])
+
+
+def get_profile_achievements(username: str) -> List[Achievement]:
+    """Get achievements of a specific profile
+
+    Args:
+        username (str): username
+
+    Returns:
+        List[Achievement]: List of achievements held by user profile
+    """
+    return get_profile_by_username(username).achievementShowcase
 
 
 def set_profile_status(sess: Session, status: ProfileStatus) -> None:

--- a/src/pywmapi/profile/api.py
+++ b/src/pywmapi/profile/api.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import requests
 
 from ..auth import Session, User

--- a/src/pywmapi/profile/api.py
+++ b/src/pywmapi/profile/api.py
@@ -42,9 +42,7 @@ def get_profile_by_username(username: str) -> Profile:
     res = requests.get(
         API_BASE_URL + f"/user/{username}",
     )
-    achievementRes = requests.get(
-        API_BASE_URL + f"/achievements/user/{username}" 
-    )
+    achievementRes = requests.get(API_BASE_URL + f"/achievements/user/{username}")
     check_wm_response(res)
     check_wm_response(achievementRes)
     return Profile.from_dict(res.json()["data"], achievementRes.json()["data"])

--- a/src/pywmapi/profile/api.py
+++ b/src/pywmapi/profile/api.py
@@ -50,7 +50,7 @@ def get_profile_by_username(username: str) -> Profile:
     return Profile.from_dict(res.json()["data"], achievementRes.json()["data"])
 
 
-def get_profile_achievements(username: str) -> List[Achievement]:
+def get_profile_achievements(username: str) -> List[Profile.Achievement]:
     """Get achievements of a specific profile
 
     Args:

--- a/src/pywmapi/profile/models.py
+++ b/src/pywmapi/profile/models.py
@@ -16,6 +16,7 @@ class Profile(ModelBase):
     @define
     class Achievement:
         id: str
+        name:str
         icon: str
         description: str
         # might be always `patreon`
@@ -37,7 +38,6 @@ class Profile(ModelBase):
     reputation: int
     about: str
     own_profile: bool
-    achievementShowcase: Optional[Achievement]
     banMessage: Optional[str] = None
     background: Optional[str] = None
 
@@ -57,7 +57,6 @@ class Profile(ModelBase):
             reputation=data.get("reputation"),
             about=data.get("about"),
             own_profile=data.get("ownProfile", False),
-            achievementShowcase=data.get("achievementShowcase"),
             banMessage=data.get("banMessage"),
             background=data.get("background"),
         )

--- a/src/pywmapi/profile/models.py
+++ b/src/pywmapi/profile/models.py
@@ -18,6 +18,7 @@ class Profile(ModelBase):
         id: str
         name:str
         icon: str
+        thumb: str
         description: str
         # might be always `patreon`
         type: str
@@ -38,11 +39,31 @@ class Profile(ModelBase):
     reputation: int
     about: str
     own_profile: bool
+    achievementShowcase: Optional[List[Achievement]]
     banMessage: Optional[str] = None
     background: Optional[str] = None
 
     @classmethod
-    def from_dict(cls, data: dict) -> "Profile":
+    def from_dict(cls, data: dict, achievementData: dict) -> "Profile":
+
+        achievements = None
+
+        if achievementData:
+            achievements = []
+            for item in achievementData:
+                en_data = item.get("i18n").get("en")
+
+                achievement = cls.Achievement(
+                    id=item.get("id"),
+                    type=item.get("type"),
+                    name=en_data.get("name", "Unknown"),
+                    description=en_data.get("description", ""),
+                    icon=en_data.get("icon"),
+                    thumb=en_data.get("thumb"),
+                )
+                
+                achievements.append(achievement)
+
         return cls(
             id=data.get("id"),
             slug=data.get("slug"),
@@ -57,6 +78,7 @@ class Profile(ModelBase):
             reputation=data.get("reputation"),
             about=data.get("about"),
             own_profile=data.get("ownProfile", False),
+            achievementShowcase=achievements,
             banMessage=data.get("banMessage"),
             background=data.get("background"),
         )

--- a/src/pywmapi/profile/models.py
+++ b/src/pywmapi/profile/models.py
@@ -16,7 +16,7 @@ class Profile(ModelBase):
     @define
     class Achievement:
         id: str
-        name:str
+        name: str
         icon: str
         thumb: str
         description: str
@@ -61,7 +61,7 @@ class Profile(ModelBase):
                     icon=en_data.get("icon"),
                     thumb=en_data.get("thumb"),
                 )
-                
+
                 achievements.append(achievement)
 
         return cls(


### PR DESCRIPTION
Profile achievements don't seem to show up in the API response for `/user/{slug}` as of v2. To fix this, the API call `/achievements/user/{slug}` is used.

Additionally, given that every previous command has been ported to v2 (excluding those without current support due to either deprecation or change in permissions policy from the API), I suggest a bump to either version `1.3.0` or `2.0.0`.
